### PR TITLE
fix(deps): update to cli-table3

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,7 +3,7 @@
 const pkg = require('../package.json');
 const commander = require('commander');
 const _ = require('lodash');
-var Table = require('cli-table2');
+var Table = require('cli-table3');
 
 const files = require('./files');
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.5.0",
-    "cli-table2": "^0.2.0",
+    "cli-table3": "^0.5.0",
     "commander": "^2.11.0",
     "lodash": "^4.17.4",
     "pino": "^4.7.1",


### PR DESCRIPTION
This PR updates the `cli-table2` dependency to `cli-table3`, which fixes one of the `npm audit` warnings :)

`cli-table2` (like `cli-table` itself) is no longer maintained. In jamestalmage/cli-table2#43 a couple of people have offered to take over maintenance but the current maintainer did not respond so as a result the project was forked to https://github.com/cli-table/cli-table3.